### PR TITLE
Fix: Disqus not showing, for error on  book.json

### DIFF
--- a/book.json
+++ b/book.json
@@ -11,6 +11,6 @@
         }
     },
     "styles": {
-        "website": "styles/website.css",
+        "website": "styles/website.css"
     }
 }


### PR DESCRIPTION
Sorry for last commit, there was an error for that Disqus not showing right now. This commit fixed this issue. Thanks.